### PR TITLE
Logging Configurability for Martini

### DIFF
--- a/martini.go
+++ b/martini.go
@@ -113,11 +113,24 @@ type ClassicMartini struct {
 	Router
 }
 
+// ClassicWithLogger creates a classic Martini with some basic default middleware - martini.Logger, martini.Recovery and martini.Static.
+// ClassicWithLogger also maps martini.Routes as a service.
+// ClassicWithLogger also allows you to specify your own custom logger.
+func ClassicWithLogger(logger *log.Logger) *ClassicMartini {
+	r := NewRouter()
+	m := NewWithLogger(logger)
+	return newClassic(m, r)
+}
+
 // Classic creates a classic Martini with some basic default middleware - martini.Logger, martini.Recovery and martini.Static.
 // Classic also maps martini.Routes as a service.
 func Classic() *ClassicMartini {
 	r := NewRouter()
 	m := New()
+	return newClassic(m, r)
+}
+
+func newClassic(m *Martini, r Router) *ClassicMartini {
 	m.Use(Logger())
 	m.Use(Recovery())
 	m.Use(Static("public"))

--- a/martini.go
+++ b/martini.go
@@ -34,12 +34,18 @@ type Martini struct {
 	logger   *log.Logger
 }
 
-// New creates a bare bones Martini instance. Use this method if you want to have full control over the middleware that is used.
-func New() *Martini {
-	m := &Martini{Injector: inject.New(), action: func() {}, logger: log.New(os.Stdout, "[martini] ", 0)}
+// New creates a bare bones Martini instance with the log recorded with the given logger. Use this if you want to have full
+// control of the middleware that is used and want to have specific control of the logger being used.
+func NewWithLogger(logger *log.Logger) *Martini {
+	m := &Martini{Injector: inject.New(), action: func() {}, logger: logger}
 	m.Map(m.logger)
 	m.Map(defaultReturnHandler())
 	return m
+}
+
+// New creates a bare bones Martini instance. Use this method if you want to have full control over the middleware that is used.
+func New() *Martini {
+	return NewWithLogger(log.New(os.Stdout, "[martini] ", 0))
 }
 
 // Handlers sets the entire middleware stack with the given Handlers. This will clear any current middleware handlers.


### PR DESCRIPTION
Right now, we have to do some janky/magic os.Stdout redirection so that Martini doesn't flood the logs with messages about the REST operations. This attempts to fix that by allowing the use of a configurable logger.

 Also, as is, Martini's logging won't work well for Splunk or any other type of searchable logging service.

Thoughts?
